### PR TITLE
Memory fixes

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -66,8 +66,9 @@ int main(int argc, char *argv[]) {
         static_cast<std::ifstream*>(src)->seekg(pos, static_cast<std::ifstream*>(src)->beg);
     };
     RIFF::RIFF riff;
-    std::ifstream* file = new std::ifstream(sf_path, std::ios::binary);
-    stream.src = file;
+
+    auto file = std::make_unique<std::ifstream>(sf_path, std::ios::binary);
+    stream.src = file.get();
     riff.parse(stream, false);
 
     //setup soundfont synthesizer and 1 channel


### PR DESCRIPTION
This branch replaces the use of `new/delete` with `std::unique_ptr` and fixes memory issues:
- Uses of `delete` instead of `delete[]` causes memory leaks in places
- Some data is never deleted (e.g. presets)
- Some values are used uninitialized

All of this is fixed by using `std::make_unique` which value-initializes by default.